### PR TITLE
Make xcodebuild -sdk configurable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
 
   # Change these as appropriate
   s.name              = "xcodebuilder"
-  s.version           = "0.1.10"
+  s.version           = "0.1.11"
   s.summary           = "A set of Rake tasks and utilities for building and releasing xcode projects"
   s.authors           = ["Olivier Larivain"]
   s.email             = ["olarivain@gmail.com"]
@@ -45,7 +45,7 @@ end
 # be automatically building a gem for this project. If you're not
 # using GitHub, edit as appropriate.
 #
-# To publish your gem online, install the 'gemcutter' gem; Read more 
+# To publish your gem online, install the 'gemcutter' gem; Read more
 # about that here: http://gemcutter.org/pages/gem_docs
 Gem::PackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ spec = Gem::Specification.new do |s|
 
   # Change these as appropriate
   s.name              = "xcodebuilder"
-  s.version           = "0.1.11"
+  s.version           = "0.1.10"
   s.summary           = "A set of Rake tasks and utilities for building and releasing xcode projects"
   s.authors           = ["Olivier Larivain"]
   s.email             = ["olarivain@gmail.com"]

--- a/lib/xcode_builder.rb
+++ b/lib/xcode_builder.rb
@@ -13,6 +13,7 @@ module XcodeBuilder
       @configuration = Configuration.new(
         :configuration => "Release",
         :build_dir => "build",
+        :sdk => "iphoneos",
         :project_file_path => nil,
         :workspace_file_path => nil,
         :scheme => nil,
@@ -53,7 +54,7 @@ module XcodeBuilder
 
       return master_repo + Array(@configuration.pod_repo_sources)
     end
-    
+
     # desc "Clean the Build"
     def clean
       unless @configuration.skip_clean
@@ -62,7 +63,7 @@ module XcodeBuilder
         puts "Done"
       end
     end
-    
+
     # desc "Build the beta release of the app"
     def build
       clean unless @configuration.skip_clean
@@ -75,21 +76,21 @@ module XcodeBuilder
       raise "** BUILD FAILED **" unless success
       puts "Done"
     end
-    
+
     # desc "Package the release as a distributable archive"
     def package
       build
 
-      print "Packaging and Signing..."        
-      if (@configuration.signing_identity != nil) then 
-        puts "" 
-        print "Signing identity: #{@configuration.signing_identity}" 
+      print "Packaging and Signing..."
+      if (@configuration.signing_identity != nil) then
+        puts ""
+        print "Signing identity: #{@configuration.signing_identity}"
       end
 
       # trash and create the dist IPA path if needed
       FileUtils.rm_rf @configuration.package_destination_path unless !File.exists? @configuration.package_destination_path
       FileUtils.mkdir_p @configuration.package_destination_path
-    
+
       # Construct the IPA and Sign it
       cmd = []
       cmd << "/usr/bin/xcrun"
@@ -108,7 +109,7 @@ module XcodeBuilder
       cmd << "2>&1 /dev/null"
       cmd = cmd.join(" ")
       system(cmd)
-      
+
       if @configuration.watch_app then
         reinject_wk_stub_in_ipa
       end
@@ -162,7 +163,7 @@ module XcodeBuilder
       # deploy or package depending on configuration
       if @configuration.deployment_strategy then
         deploy
-      else 
+      else
         package
       end
 

--- a/lib/xcode_builder/configuration.rb
+++ b/lib/xcode_builder/configuration.rb
@@ -132,7 +132,7 @@ module XcodeBuilder
     end
 
     def built_app_path
-      File.join("#{build_dir}", "#{configuration}-iphoneos", "#{app_file_name}")
+      File.join("#{build_dir}", "#{configuration}-#{sdk}", "#{app_file_name}")
     end
 
     def ipa_path

--- a/lib/xcode_builder/configuration.rb
+++ b/lib/xcode_builder/configuration.rb
@@ -21,19 +21,19 @@ module XcodeBuilder
         args << "-project '#{project_file_path}'" if project_file_path
       end
 
-      args << "-sdk iphoneos"
-      
+      args << "-sdk #{sdk}"
+
       args << "-configuration '#{configuration}'"
       args << "BUILD_DIR=\"#{File.expand_path build_dir}\""
-      
+
       if xcodebuild_extra_args
           args.concat xcodebuild_extra_args if xcodebuild_extra_args.is_a? Array
           args << "#{xcodebuild_extra_args}" if xcodebuild_extra_args.is_a? String
       end
-      
+
       args
     end
-    
+
     def app_file_name
       raise ArgumentError, "app_name or target must be set in the BetaBuilder configuration block" if app_name.nil?
       "#{app_name}.app"
@@ -54,7 +54,7 @@ module XcodeBuilder
         version_line = file.gets
       end while version_line.eql? "\n"
 
-      if match = version_line.match(/\s*version\s*=\s*["'](.*)["']\s*/i) 
+      if match = version_line.match(/\s*version\s*=\s*["'](.*)["']\s*/i)
         version = match.captures
       end
       return version[0]
@@ -121,16 +121,16 @@ module XcodeBuilder
     def ipa_name
       prefix = app_name == nil ? target : app_name
       "#{prefix}#{built_app_long_version_suffix}.ipa"
-    end      
+    end
 
     def built_app_long_version_suffix
       if build_number == nil then
         ""
-      else 
+      else
         "-#{build_number}"
       end
     end
-    
+
     def built_app_path
       File.join("#{build_dir}", "#{configuration}-iphoneos", "#{app_file_name}")
     end
@@ -142,7 +142,7 @@ module XcodeBuilder
     def app_bundle_path
       "#{package_destination_path}/#{app_name}.app"
     end
-    
+
     def deploy_using(strategy_name, &block)
       if DeploymentStrategies.valid_strategy?(strategy_name.to_sym)
         self.deployment_strategy = DeploymentStrategies.build(strategy_name, self)


### PR DESCRIPTION
-sdk is currently hardcoded to iphoneos. This pull request makes it configurable via the configuration class. The default sdk has been preserved as iphoneos.
